### PR TITLE
updated package.json build script

### DIFF
--- a/suncityla/package-lock.json
+++ b/suncityla/package-lock.json
@@ -12,7 +12,8 @@
         "next": "15.0.3",
         "prisma": "^5.22.0",
         "react": "19.0.0-rc-66855b96-20241106",
-        "react-dom": "19.0.0-rc-66855b96-20241106"
+        "react-dom": "19.0.0-rc-66855b96-20241106",
+        "solar-friend": "file:"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -6668,6 +6669,10 @@
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
+    },
+    "node_modules/solar-friend": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/suncityla/package-lock.json
+++ b/suncityla/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "solar-friend",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "next": "15.0.3",

--- a/suncityla/package.json
+++ b/suncityla/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && prisma generate",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest",
@@ -12,7 +12,8 @@
     "prisma:migrate": "prisma migrate dev",
     "prisma:update": "npm run prisma:generate && npm run prisma:migrate",
     "prisma:studio": "prisma studio",
-    "prisma:seed": "prisma db seed"
+    "prisma:seed": "prisma db seed",
+    "build:vercel": "npm run build && npm run prisma:generate"
   },
   "prisma": {
     "seed": "node prisma/seed.js"

--- a/suncityla/package.json
+++ b/suncityla/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && prisma generate",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest",
@@ -22,7 +22,8 @@
     "next": "15.0.3",
     "prisma": "^5.22.0",
     "react": "19.0.0-rc-66855b96-20241106",
-    "react-dom": "19.0.0-rc-66855b96-20241106"
+    "react-dom": "19.0.0-rc-66855b96-20241106",
+    "solar-friend": "file:"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
I have updated the package.json after encountering an issue with deployment on vercel. 
The issue is:
`[cause]: Error [PrismaClientInitializationError]: Prisma has detected that this project was built on Vercel, which caches dependencies. This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered. To fix this, make sure to run the prisma generate command during the build process`